### PR TITLE
refactor: 상세조회, 참여자 조회에 해당 사람의 id를 응답에 추가

### DIFF
--- a/src/main/java/com/example/knu_connect/domain/networking/dto/response/NetworkingDetailResponseDto.java
+++ b/src/main/java/com/example/knu_connect/domain/networking/dto/response/NetworkingDetailResponseDto.java
@@ -32,6 +32,10 @@ public record NetworkingDetailResponseDto(
 ) {
     @Schema(description = "대표자 정보")
     public record RepresentativeDto(
+
+            @Schema(description = "아이디", example = "1L")
+            Long id,
+
             @Schema(description = "이름", example = "홍길동")
             String name,
 

--- a/src/main/java/com/example/knu_connect/domain/networking/dto/response/ParticipantsResponseDto.java
+++ b/src/main/java/com/example/knu_connect/domain/networking/dto/response/ParticipantsResponseDto.java
@@ -11,6 +11,9 @@ public record ParticipantsResponseDto(
 ) {
     @Schema(description = "참여자 정보")
     public record ParticipantDto(
+            @Schema(description = "아이디", example = "1L")
+            Long id,
+
             @Schema(description = "이름", example = "홍길동")
             String name,
 

--- a/src/main/java/com/example/knu_connect/domain/networking/service/NetWorkingServiceImpl.java
+++ b/src/main/java/com/example/knu_connect/domain/networking/service/NetWorkingServiceImpl.java
@@ -129,6 +129,7 @@ public class NetWorkingServiceImpl implements NetworkingService {
 
         NetworkingDetailResponseDto.RepresentativeDto representativeDto =
                 new NetworkingDetailResponseDto.RepresentativeDto(
+                        representative.getId(),
                         representative.getName(),
                         representative.getStatus().name(),
                         representative.getDepartment().name(),
@@ -206,6 +207,7 @@ public class NetWorkingServiceImpl implements NetworkingService {
                 .map(cp -> {
                     User participant = cp.getUser();
                     return new ParticipantsResponseDto.ParticipantDto(
+                            participant.getId(),
                             participant.getName(),
                             participant.getStatus().name(),
                             participant.getDepartment().name(),


### PR DESCRIPTION
## ✨ 요약

추후 네트워킹 수정 등에 사용하기 위해 조회 시 응답에 유저 id를 추가한다.

## 🔗 작업 내용

- 네트워킹 상세 조회에 대표자 아이디 추가
- 네트워킹 참여자 리스트 조회에 참여자 아이디 추가

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #53 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)